### PR TITLE
Enforces #to_s on the contents of the message

### DIFF
--- a/lib/hatchet/message.rb
+++ b/lib/hatchet/message.rb
@@ -76,7 +76,7 @@ module Hatchet
     # Public: Returns the String representation of the message.
     #
     def to_s
-      @message ||= @block.call
+      (@message ||= @block.call).to_s
     end
 
   end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -3,11 +3,31 @@
 require_relative 'spec_helper'
 
 describe Message do
+  describe 'providing an evaluted message that is not a string' do
+    let(:subject) { Message.new(ndc: [], message: Rational(1.5)) }
+
+    it 'returns the given message' do
+      assert_equal '3/2', subject.to_s
+    end
+  end
+
   describe 'providing an evaluted message' do
     let(:subject) { Message.new(ndc: [], message: 'Evaluated') }
 
     it 'returns the given message' do
       assert_equal 'Evaluated', subject.to_s
+    end
+  end
+
+  describe 'providing a block message that does not return a string' do
+    let(:subject) do
+      Message.new(ndc: []) do
+        Rational(1.5)
+      end
+    end
+
+    it 'returns the result of evaluating the block and calling #to_s on the result' do
+      assert_equal '3/2', subject.to_s
     end
   end
 


### PR DESCRIPTION
This is done for both the directly supplied message and block form
