### PR TITLE
Remove memoization of NDC

### DIFF
--- a/lib/hatchet/hatchet_logger.rb
+++ b/lib/hatchet/hatchet_logger.rb
@@ -386,7 +386,7 @@ module Hatchet
       # Ensure configuration and context set - can be lost by marshalling and
       # unmarshalling the logger.
       @configuration ||= Hatchet.configuration
-      @ndc ||= Hatchet::NestedDiagnosticContext.current
+      @ndc = Hatchet::NestedDiagnosticContext.current
 
       msg = Message.new(ndc: @ndc.context.clone, message: message, error: error, backtrace_filters: @configuration.backtrace_filters, &block)
 


### PR DESCRIPTION
It's possible to memorize the NDC object while it has no context, leaving the context blank in the logs later.
This PR removes the memoization to ensure the current NDC is always used when appending messages.